### PR TITLE
update campus redirect to TUMonline 3.0 URL

### DIFF
--- a/redirect/routes.php
+++ b/redirect/routes.php
@@ -24,7 +24,7 @@ class Route {
         ],
         'c'            => [
             'description' => 'TUM Online',
-            'target'      => 'https://campus.tum.de/tumonline/anmeldung.durchfuehren',
+            'target'      => 'https://campus.tum.de/tumonline/ee/ui/ca2/app/desktop/#/login',
         ],
         'm'            => [
             'description' => 'Moodle',


### PR DESCRIPTION
This PR updates the campus / c redirect to use a TUMonline 3.0 URL, to avoid an extra redirect to the login form.