### PR TITLE
Fix moodle redirects (#56)

### DIFF
--- a/redirect/routes.php
+++ b/redirect/routes.php
@@ -812,12 +812,12 @@ class Route {
         switch ($siteType) {
             case 'm' :
                 // This is a moodle redirect like minfo1.tum.sexy
-                $moodle_id = $this->routes[$redirectUrl];
-                if (!isset($moodle_id['moodle_id'])) {
-                    return $this->routes[$redirectUrl]['target'];  // Fallback to target if moodle id is unknown
+                $route = $this->routes[$redirectUrl];
+                if (!isset($route['moodle_id'])) {
+                    return $route['target'];  // Fallback to target if moodle id is unknown
                 }
 
-                return 'https://www.moodle.tum.de/course/view.php?id=' . $moodle_id['moodle_id'];
+                return 'https://www.moodle.tum.de/course/view.php?id=' . $route['moodle_id'];
         }
 
         return $this->routes[$redirectUrl]['target'];

--- a/redirect/routes.php
+++ b/redirect/routes.php
@@ -811,13 +811,13 @@ class Route {
         //In case we actually want to go to a different target than the actual redirect
         switch ($siteType) {
             case 'm' :
-                // This is a moodle redirect like m.info1.tum.sexy
-                $moodle_id = $this->routes[$redirectUrl]['moodle_id'];
-                if (!isset($moodle_id)) {
+                // This is a moodle redirect like minfo1.tum.sexy
+                $moodle_id = $this->routes[$redirectUrl];
+                if (!isset($moodle_id['moodle_id'])) {
                     return $this->routes[$redirectUrl]['target'];  // Fallback to target if moodle id is unknown
                 }
 
-                return 'https://www.moodle.tum.de/course/view.php?id=' . $moodle_id;
+                return 'https://www.moodle.tum.de/course/view.php?id=' . $moodle_id['moodle_id'];
         }
 
         return $this->routes[$redirectUrl]['target'];


### PR DESCRIPTION
This PR addresses #56.

I believe that the underlying issue is, that a warning will be printed. With it, the user cannot be redirected. Unfortunately, I could only test it locally.

- [x] I made sure that the arrays in `routes.php` are still alphabetically sorted. :sparkles: 
Of course. Had nothing to do with the array.