### PR TITLE
Updated Studienplan B.Sc. Informatik to WS21/22 version

### DIFF
--- a/redirect/routes.php
+++ b/redirect/routes.php
@@ -545,7 +545,7 @@ class Route {
         ],
         'sp'               => [
             'description' => 'Studienplan B.Sc. Informatik',
-            'target'      => 'https://www.in.tum.de/fuer-studierende/bachelor-studiengaenge/informatik/studienplan/studienbeginn-ab-ws-201819/',
+            'target'      => 'https://www.in.tum.de/fuer-studierende/bachelor-studiengaenge/informatik/studienplan/studienbeginn-ab-wise-202122/',
         ],
         'springer'         => [
             'description' => 'Springer Link Login',


### PR DESCRIPTION
## Problem

As the Studienplan for the Bachelor of Informatics has changed, the redirect https://sp.tum.sexy is broken and leads to a TUM 404 error page.

## Solution

Updated the redirect link so that the redirect points to the [new Studienplan](https://www.in.tum.de/fuer-studierende/bachelor-studiengaenge/informatik/studienplan/studienbeginn-ab-wise-202122/).