### PR TITLE
Update link to eduroam cat

### DIFF
--- a/tpl/eduroam.twig
+++ b/tpl/eduroam.twig
@@ -5,7 +5,7 @@
     <h3>How to configure your eduroam securely</h3>
     <ul>
         <li>Don't setup your eduroam on Android manually, because it is <strong>not secure</strong>!</li>
-        <li>Use the automatic setup of the <a href="http://app.tum.sexy">TUM Campus App</a> (recommended) or use a profile from <a href="https://cat.eduroam.de/">Eduroam CAT</a>.</li>
+        <li>Use the automatic setup of the <a href="http://app.tum.sexy">TUM Campus App</a> (recommended) or use a profile from <a href="https://cat.eduroam.org/">Eduroam CAT</a>.</li>
         <li>If configured wrongly, third parties are able to see your password in plaintext.</li>
     </ul>
 


### PR DESCRIPTION
cat.eduroam.de has been discontinued and is now cat.eduroam.org