### PR TITLE
:sparkles: add gpp (alias for pgdp)

### DIFF
--- a/redirect/routes.php
+++ b/redirect/routes.php
@@ -664,6 +664,7 @@ class Route {
         'gdb'            => 'db',
         'geo'            => 'geokalkuele',
         'geokal'         => 'geokalkuele',
+        'gpp'            => 'pgdp',
         'hsw'            => 'wahl',
         'info2'          => 'fpv',
         'kino'           => 'film',


### PR DESCRIPTION
Since ws21/22 Praktikum: Grundlagen der Programmierung is called Grundlagenpraktikum: Programmierung, or short "GPP".
For now, I would suggest not to rename Praktikum Grundlagen der Programmierung to Grundlagenpraktikum: Programmierung on tum.sexy yet, as everybody is used to saying "PGdP". Instead, introducing "gpp" as an alias might be just fine for now. 

Sources: 
- [Semesterplan](https://www.in.tum.de/fuer-studierende/bachelor-studiengaenge/informatik/studienplan/studienbeginn-ab-wise-202122/)
- [Moodle course](https://campus.tum.de/tumonline/WBMODHB.wbShowMHBReadOnly?pKnotenNr=452806&pOrgNr=14189)

- [x] I made sure that the arrays in `routes.php` are still alphabetically sorted. :sparkles: 