### PR TITLE
Update GitHub actions

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -8,3 +8,7 @@ updates:
     directory: "/" # Location of package manifests
     schedule:
       interval: "monthly"
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "monthly"

--- a/.github/workflows/master.yml
+++ b/.github/workflows/master.yml
@@ -7,15 +7,30 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - name: Checkout repository
-      uses: actions/checkout@v1
-    - name: Build and push Docker images
-      uses: docker/build-push-action@v1.1.0
+      uses: actions/checkout@v2
+    - name: Docker meta
+      id: meta
+      uses: docker/metadata-action@v3
       with:
+        images: tum-dev/tum.sexy/sexy-server
+        tags: |
+          type=ref,event=branch
+          type=ref,event=pr
+          type=semver,pattern={{version}}
+          type=sha
+    - name: Set up Docker Buildx
+      uses: docker/setup-buildx-action@v1
+    - name: Login to DockerHub
+      uses: docker/login-action@v1
+      with:
+        registry: docker.pkg.github.com
         username: ${{ github.actor }}
         password: ${{ github.token }}
-        registry: docker.pkg.github.com
-        repository: tum-dev/tum.sexy/sexy-server
-        tags: latest
-        tag_with_ref: true
-        tag_with_sha: true
-        add_git_labels: true
+    - name: Build and push Docker images
+      uses: docker/build-push-action@v2
+      with:
+        context: .
+        pull: true
+        push: true
+        tags: ${{ steps.meta.outputs.tags }}
+        labels: ${{ steps.meta.outputs.labels }}


### PR DESCRIPTION
This PR adds GitHub actions to Dependabot. In addition, `docker/build-push-action` was updated to v2, which splits the functionality of v1 into multiple actions. I tried to translate the functionality of v1 to v2 following the upgrade guide [https://github.com/docker/build-push-action/blob/master/UPGRADE.md](https://github.com/docker/build-push-action/blob/master/UPGRADE.md). However, I cannot test these changes.