### PR TITLE
Fix resource links

### DIFF
--- a/js/pins.js
+++ b/js/pins.js
@@ -2,13 +2,7 @@ let pins = [];
 
 function removePin(elem) {
     let remove = elem.parentElement.children[1].innerHTML
-    let newPins = []
-    pins.forEach(pin => {
-        if (pin.n !== remove) {
-            newPins.push(pin)
-        }
-    })
-    pins = newPins
+    pins = pins.filter(pin => pin.n !== remove)
     localStorage.setItem("pins", JSON.stringify(pins))
     render()
 }
@@ -35,6 +29,8 @@ function render() {
 }
 
 window.onload = function () {
-    pins = JSON.parse(localStorage.getItem("pins") === null ? "[]" : localStorage.getItem("pins"))
-    render()
+    if (document.getElementById("pins")){
+        pins = JSON.parse(localStorage.getItem("pins") === null ? "[]" : localStorage.getItem("pins"))
+        render()
+    }
 }

--- a/tpl/head.twig
+++ b/tpl/head.twig
@@ -10,8 +10,8 @@
 <link rel="stylesheet" href="/css/skeleton.css">
 <link rel="stylesheet" href="/css/balloon.min.css">
 <link rel="stylesheet" href="/css/custom.css">
-<script src="js/pins.js"></script>
+<script src="/js/pins.js"></script>
 
 <link rel="search" href="opensearchdescription.xml" type="application/opensearchdescription+xml" title="tum.sexy"/>
 
-<link rel="icon" type="image/png" href="favicon.png"/>
+<link rel="icon" type="image/png" href="/favicon.png"/>


### PR DESCRIPTION
The resource links in the HTML head were incorrect for pages other than the main page. Since resources are now loaded correctly, JS code for pins was executed on pages without pins, resulting in errors, which was also fixed.