### PR TITLE
Use GitHub container registry

### DIFF
--- a/.github/workflows/master.yml
+++ b/.github/workflows/master.yml
@@ -23,9 +23,9 @@ jobs:
     - name: Login to DockerHub
       uses: docker/login-action@v1
       with:
-        registry: docker.pkg.github.com
+        registry: ghcr.io
         username: ${{ github.actor }}
-        password: ${{ github.token }}
+        password: ${{ secrets.GITHUB_TOKEN }}
     - name: Build and push Docker images
       uses: docker/build-push-action@v2
       with:


### PR DESCRIPTION
This PR replaces the outdated GitHub docker registry with GitHub container registry.
Changes based on [https://github.com/docker/login-action#github-container-registry](https://github.com/docker/login-action#github-container-registry)