### PR TITLE
add route to exam stats

### DIFF
--- a/redirect/routes.php
+++ b/redirect/routes.php
@@ -583,6 +583,10 @@ class Route {
             'description' => 'Statista',
             'target'      => 'https://de-statista-com.eaccess.ub.tum.de',
         ],
+        'stats'            => [
+            'description' => 'Prüfungsstatistiken',
+            'target'      => 'https://home.stusta.de/~013107/cgi-bin/show_stat.cgi',
+        ],
         'streams'          => [
             'description' => 'RBGreaterAgain - Bessere RBG streams',
             'target'      => 'https://stream.tum.sexy',


### PR DESCRIPTION
'stats' -> '[https://home.stusta.de/~013107/cgi-bin/show_stat.cgi](https://home.stusta.de/~013107/cgi-bin/show_stat.cgi)'

- [x] I made sure that the arrays in `routes.php` are still alphabetically sorted. :sparkles: 