### PR TITLE
Update eduroam setup instructions

### DIFF
--- a/tpl/eduroam.twig
+++ b/tpl/eduroam.twig
@@ -4,8 +4,8 @@
 <div class="row" style="margin-top:10%; text-align: center;">
     <h3>How to configure your eduroam securely</h3>
     <ul>
-        <li>Don't setup your eduroam on Android manually, because it is <strong>not secure</strong>!</li>
-        <li>Use the automatic setup of the <a href="http://app.tum.sexy">TUM Campus App</a> (recommended) or use a profile from <a href="https://cat.eduroam.org/">Eduroam CAT</a>.</li>
+        <li>Eduroam setup on Android is secure even without CAT. Please have a look at the <a href="https://doku.lrz.de/pages/viewpage.action?pageId=39093089">setup instructions</a>.</li>
+        <li>For all other operating systems, use the automatic setup of the <a href="http://app.tum.sexy">TUM Campus App</a> (recommended) or use a profile from <a href="https://cat.eduroam.org/">Eduroam CAT</a>.</li>
         <li>If configured wrongly, third parties are able to see your password in plaintext.</li>
     </ul>
 
@@ -14,8 +14,6 @@
 
     <h5>Further readings / References</h5>
     <ul>
-        <li><a href="https://www.dfn-cert.de/aktuell/Google-Android-Eduroam-Zugangsdaten.html">Bug description on DFN CERT</a></li>
-        <li><a href="https://lists.lrz.de/pipermail/tum-it-newsletter/2016-February/000094.html">TUM-IT-Newsletter</a></li>
-        <li><a href="https://www.lrz.de/services/netz/mobil/802_1x/android_en/">LRZ: eduroam with Android</a></li>
+        <li><a href="https://doku.lrz.de/display/PUBLIC/eduroam">LRZ: eduroam CAT profile download</a></li>
     </ul>
 </div>


### PR DESCRIPTION
The eduroam setup instructions were outdated.
I updated the instructions and fixed a broken link.