### PR TITLE
add moodle_it to gad

### DIFF
--- a/redirect/routes.php
+++ b/redirect/routes.php
@@ -230,6 +230,7 @@ class Route {
         'gad'              => [
             'description' => 'Grundlegende Algorithmen und Datenstrukturen',
             'target'      => 'https://artemis.ase.in.tum.de/courses/184',
+            'moodle_id'   => '75236',
         ],
         'gadunittests'     => [
             'description' => 'Unit - Tests: Grundlegende Algorithmen und Datenstrukturen',


### PR DESCRIPTION
- [x] I made sure that the arrays in `routes.php` are still alphabetically sorted. :sparkles: 

Add moodle id for the [GAD moodle course](https://www.moodle.tum.de/course/view.php?id=75236) so that `mgad.tum.sexy` redirects to the moodle course. :tada: 