### PR TITLE
gbs: update moodle id, also in MainTest

### DIFF
--- a/redirect/routes.php
+++ b/redirect/routes.php
@@ -246,7 +246,7 @@ class Route {
         ],
         'gbs'              => [
             'description' => 'Grundlagen: Betriebssysteme und Systemsoftware',
-            'moodle_id'   => '68990',
+            'moodle_id'   => '80270',
         ],
         'ge-ma-sp'         => [
             'description' => 'Studienplan M.Sc. Informatik: Games Engineering',

--- a/tests/General/MainTest.php
+++ b/tests/General/MainTest.php
@@ -12,7 +12,7 @@ class MainTest extends \PHPUnit\Framework\TestCase {
         $this->assertEquals('https://tum.sexy/', $router->getTargetOfSub('kjhdsfjkdfsgkjldsfgkjl.tum.sexy'));
 
         // SiteType redirect to moodle
-        $this->assertStringContainsString('https://www.moodle.tum.de/course/view.php?id=68990', $router->getTargetOfSub('mgbs.tum.sexy'));
+        $this->assertStringContainsString('https://www.moodle.tum.de/course/view.php?id=80270', $router->getTargetOfSub('mgbs.tum.sexy'));
 
         // Normal redirect still works, even if it has moodle type assigned
         $this->assertStringContainsString('https://db.in.tum.de/teaching/ws2223/grundlagen/?lang=de', $router->getTargetOfSub('db.tum.sexy'));


### PR DESCRIPTION
- [x] I made sure that the arrays in `routes.php` are still alphabetically sorted. :sparkles: 

New semester, new moodle id...

Updated id for Grundlagen: Betriebssysteme und Systemsoftware (IN0009)

The test in `MainTest.php` checks the redirection of this course, therefor updating the moodle id there aswell :tada: 