### PR TITLE
Add option to persist referer in redirect url

### DIFF
--- a/redirect/index.php
+++ b/redirect/index.php
@@ -2,5 +2,16 @@
 
 include __DIR__ . '/routes.php';
 $routeHandler = new Route();
-header('Location: ' . $routeHandler->getTargetOfSub($_SERVER['HTTP_HOST'])); // Function does check if GET parameter is set / empty
+$target = $routeHandler->getTargetOfSub($_SERVER['HTTP_HOST']);// Function does check if GET parameter is set / empty
+
+if($routeHandler->shouldAddReferer($_SERVER['HTTP_HOST'])) {
+    if(str_contains($target, '?')) {
+        $target .= '&'; // add & if there is a query variable in the target
+    }else {
+        $target .= '?'; // ? otherwise
+    }
+    $target .= 'r=' . urlencode($_SERVER['REQUEST_URI']);
+}
+
+header('Location: ' . $target);
 die();

--- a/redirect/routes.php
+++ b/redirect/routes.php
@@ -937,7 +937,6 @@ class Route {
 
     public function shouldAddReferer($host): bool {
         $redirectUrl = $this->getRedirectURL($host);
-        header('X-Should-Add: ' . $redirectUrl);
 
         if (isset($this->routes[$redirectUrl])) {
             return isset($this->routes[$redirectUrl]['addReferer']) && $this->routes[$redirectUrl]['addReferer'];

--- a/tests/General/MainTest.php
+++ b/tests/General/MainTest.php
@@ -18,6 +18,16 @@ class MainTest extends \PHPUnit\Framework\TestCase {
         $this->assertStringContainsString('https://db.in.tum.de/teaching/ws2223/grundlagen/?lang=de', $router->getTargetOfSub('db.tum.sexy'));
     }
 
+    public function testRefererAdding() {
+        $router = new Route();
+
+        // Don't add referer for moodle links
+        $this->assertEquals(False, $router->shouldAddReferer('m.tum.sexy'));
+
+        // add referer for TUM-Live
+        $this->assertEquals(True, $router->shouldAddReferer('l.tum.sexy'));
+    }
+
     public function testJsonOutput() {
         $router = new Route();
         $this->assertNotEmpty($router->getResolvedArrays());


### PR DESCRIPTION
This pr adds the optional attribute `addReferer` to the routes array. If set, the request query is added to the redirect as a query param like this:

```sh
curl -v https://l.tum.sexy/123?t=3m23s
...
< Location: https://live.rbg.tum.de?r=%2F123%3Ft%3D3m23s
```

Sites like TUM-Live can now decode the query and redirect users to the video 123 at the timestamp 3m23s, e.g. https://live.rbg.tum.de/w/NetSec/123?t=3m22s
