### PR TITLE
Routes for new Cryptography course

### DIFF
--- a/redirect/routes.php
+++ b/redirect/routes.php
@@ -149,7 +149,11 @@ class Route {
         ],
         'crypto'           => [
             'description' => 'Kryptographie',
-            'target'      => 'https://www7.in.tum.de/um/courses/crypto/ws2021/',
+            'target'      => 'https://www.sec.in.tum.de/i20/teaching/ss-2023/kryptografie',
+        ],
+        'crypto-moodle'    => [
+            'description' => 'Kryptographie Moodle',
+            'target'      => 'https://www.moodle.tum.de/course/view.php?id=86223',
         ],
         'csc'              => [
             'description' => 'Computational Social Choice',

--- a/redirect/routes.php
+++ b/redirect/routes.php
@@ -150,10 +150,8 @@ class Route {
         'crypto'           => [
             'description' => 'Kryptographie',
             'target'      => 'https://www.sec.in.tum.de/i20/teaching/ss-2023/kryptografie',
+            'moodle_id' => '86223',
         ],
-        'crypto-moodle'    => [
-            'description' => 'Kryptographie Moodle',
-            'target'      => 'https://www.moodle.tum.de/course/view.php?id=86223',
         ],
         'csc'              => [
             'description' => 'Computational Social Choice',

--- a/redirect/routes.php
+++ b/redirect/routes.php
@@ -152,7 +152,6 @@ class Route {
             'target'      => 'https://www.sec.in.tum.de/i20/teaching/ss-2023/kryptografie',
             'moodle_id' => '86223',
         ],
-        ],
         'csc'              => [
             'description' => 'Computational Social Choice',
             'target'      => 'https://dss.in.tum.de/teaching/ws-18-19/37-teaching/semester/wintersemster-2018-19/193-computational-social-choice-2018-19.html',


### PR DESCRIPTION
Updated the `crypto` link -> now held by @schanzen under supervision of the IT Security Chair.
Added a new `crypto-moodle` shortcut for the corresponding Moodle course.

- [x] I made sure that the arrays in `routes.php` are still alphabetically sorted. :sparkles: 