### PR TITLE
Added menu.tum.sexy to the links

### DIFF
--- a/redirect/routes.php
+++ b/redirect/routes.php
@@ -704,6 +704,10 @@ class Route {
             'description' => 'Support Elective: Think. Make. Start.',
             'target'      => 'https://www.thinkmakestart.com/',
         ],
+	'tumenu'           => [
+            'description' => 'The place, where you can find daily menus for some student places in Munich',
+            'target'      => 'https://menu.tum.sexy/',
+        ],  
         'uanal'            => [
             'description' => 'Übungen zu Analysis für Informatik',
             'moodle_id'   => '84798',
@@ -885,6 +889,7 @@ class Route {
             'springer',
             'statista',
             'streams',
+	    'tumenu',
             'vorkurs',
             'wahl',
             'walomat',


### PR DESCRIPTION
[menu.tum.sexy](menu.tum.sexy) is a static website and such as the [eat-api](https://tum-dev.github.io/eat-api/#!/en/mensa-garching) tt displays the daily menus for some student food places around Munich. It has some nice features, which the eat-api doesn't have, better design and is open-source as well [repository](https://github.com/TUM-Dev/TUMenu).

It will be great to have it as an usefull link in tum.sexy