### PR TITLE
Add TUM Chess Club redirect

### DIFF
--- a/redirect/routes.php
+++ b/redirect/routes.php
@@ -122,6 +122,10 @@ class Route {
             'description' => 'Liste der Computer Science Lehrstühle',
             'target'      => 'https://www.cs.cit.tum.de/cs/forschung/professuren/',
         ],
+	'chess'           => [
+            'description' => 'Official TUM Chess Club',
+            'target'      => 'https://home.in.tum.de/~petriroc',
+        ],
         'comp'             => [
             'description' => 'Computational Complexity',
             'target'      => 'https://www7.in.tum.de/um/courses/complexity/SS19/',


### PR DESCRIPTION
Adds a redirect to the [website](https://home.in.tum.de/~petriroc/) of the newly founded [TUM Chess Club](https://www.tum.de/community/campusleben/student-clubs#c96191).

- [x] I made sure that the arrays in `routes.php` are still alphabetically sorted. :sparkles: 