### PR TITLE
Fix subdomain matching for urls with dashes

### DIFF
--- a/deployment/charts/tum-sexy/templates/networking/ingress.yaml
+++ b/deployment/charts/tum-sexy/templates/networking/ingress.yaml
@@ -10,7 +10,7 @@ spec:
     - websecure
   routes:
     - kind: Rule
-      match: Host(`{{ $.Values.url }}`) || HostRegexp(`{{ $.Values.url }}`, `{subdomain:[a-z0-9]+}.{{ $.Values.url }}`)
+      match: Host(`{{ $.Values.url }}`) || HostRegexp(`{{ $.Values.url }}`, `{subdomain:[a-z0-9\-]+}.{{ $.Values.url }}`)
       services:
         - name: tum-sexy-svc
           port: 80
@@ -29,7 +29,7 @@ spec:
     - web
   routes:
     - kind: Rule
-      match: Host(`{{ $.Values.url }}`) || HostRegexp(`{{ $.Values.url }}`, `{subdomain:[a-z0-9]+}.{{ $.Values.url }}`)
+      match: Host(`{{ $.Values.url }}`) || HostRegexp(`{{ $.Values.url }}`, `{subdomain:[a-z0-9\-]+}.{{ $.Values.url }}`)
       services:
         - name: noop@internal
           kind: TraefikService


### PR DESCRIPTION
- [X] I made sure that the arrays in `routes.php` are still alphabetically sorted. :sparkles: 

Currently, traefik doesn't match urls like eat-api because they contain dashes which the regex doesn't match. 

Also noted in #237 