### PR TITLE
Fix link to SET website

### DIFF
--- a/redirect/routes.php
+++ b/redirect/routes.php
@@ -627,8 +627,8 @@ class Route {
             'target'      => 'https://www.semesterticket-muenchen.de',
         ],
         'set'              => [
-            'description' => 'Studieneinführungstage der FSMPI',
-            'target'      => 'https://mpi.fs.tum.de/neu-an-der-tum/set/',
+            'description' => 'Studieneinführungstage der FSMPIC',
+            'target'      => 'https://mpic.fs.tum.de/studium/studienbeginn/set/',
         ],
         'sharelatex'       => [
             'description' => 'ShareLaTeX@TUM',


### PR DESCRIPTION
- [x] I made sure that the arrays in `routes.php` are still alphabetically sorted. :sparkles: 

As part of the merge to the FSMPIC the links probably changed, too. This PR does the renaming and fixes the link.