### PR TITLE
Update URL to  app in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ Code of https://tum.sexy. A website providing some links, redirects and tools re
 * ...
 
 **Projects** like
-* CalProxy: Removes clutter from TUMOnline Calendar and optimizes it (https://cal.bruck.me/)
+* CalProxy: Removes clutter from TUMOnline Calendar and optimizes it (https://cal.tum.app/)
 
 ### Contributing
 


### PR DESCRIPTION
Updated the links to the calendar proxy, as the old one is not working any more. New link is: https://cal.tum.app/

- [x] I made sure that the arrays in `routes.php` are still alphabetically sorted. :sparkles: 