### PR TITLE
Update URL to app on the start page

### DIFF
--- a/tpl/start.twig
+++ b/tpl/start.twig
@@ -57,7 +57,7 @@
         <div class="one-half column subsection">
             <h3>Projects / Links</h3>
             <ul>
-                <li><a href="https://cal.bruck.me">Calendar Proxy</a>
+                <li><a href="https://cal.tum.app/">Calendar Proxy</a>
                     <ul>
                         <li>Nice and easy proxy to remove some clutter from the TUM online iCal export. E.g.: replaces 'Tutorübung' with 'TÜ' and Google Now readable locations</li>
                     </ul>


### PR DESCRIPTION
Updated the links to the calendar proxy, as the old one is not working any more. New link is: https://cal.tum.app/

- [x] I made sure that the arrays in `routes.php` are still alphabetically sorted. :sparkles: 