### PR TITLE
Update Cryptography course links

### DIFF
--- a/redirect/routes.php
+++ b/redirect/routes.php
@@ -172,8 +172,8 @@ class Route {
         ],
         'crypto'           => [
             'description' => 'Kryptographie',
-            'target'      => 'https://www.sec.in.tum.de/i20/teaching/ss-2024/kryptografie',
-            'moodle_id' => '96175',
+            'target'      => 'https://www.sec.in.tum.de/i20/teaching/ss-2025/kryptografie',
+            'moodle_id' => '106666',
         ],
         'csc'              => [
             'description' => 'Computational Social Choice',


### PR DESCRIPTION
New semester, new links. Updated the Moodle Id and Chair information links to correspond to the ones used in the upcoming semester

- [x] I absolutely made sure that the arrays in `routes.php` are still alphabetically sorted. :sparkles: :sparkles: :sparkles: 